### PR TITLE
Subscriber accepts list of topics or single topic

### DIFF
--- a/msb/zmq_base/Subscriber.py
+++ b/msb/zmq_base/Subscriber.py
@@ -29,17 +29,20 @@ class Subscriber:
             print(f"failed to bind to zeromq socket: {e}")
             sys.exit(-1)
 
-    def subscribe(self, topic: bytes):
+    def subscribe(self, topic: bytes | list[bytes]):
         # Acceps single topic or list of topics
-        self.socket.setsockopt(zmq.SUBSCRIBE, topic)
+        if isinstance(topic, list):
+            for t in topic:
+                self.socket.setsockopt(zmq.SUBSCRIBE, t)
+        else:
+            self.socket.setsockopt(zmq.SUBSCRIBE, topic)
 
-    def receive(self) -> tuple:
+    def receive(self) -> tuple[bytes, dict]:
         """
         reads a message from the zmq bus and returns it
 
-        returns:
-            tuple(topic, message), where topic is a byte string identifying the
-            source service of the message
+        Returns:
+            tuple(topic: bytes, message: dict): the message received
         """
         (topic, message) = self.socket.recv_multipart()
         message = self.unpacker.loads(message.decode())

--- a/msb/zmq_base/__init__.py
+++ b/msb/zmq_base/__init__.py
@@ -1,0 +1,2 @@
+from msb.zmq_base.Publisher import Publisher, get_default_publisher
+from msb.zmq_base.Subscriber import Subscriber, get_default_subscriber

--- a/test/test_zmq_wrapper.py
+++ b/test/test_zmq_wrapper.py
@@ -90,6 +90,21 @@ def test_publisher_subscriber_via_mock_broker(test_data, mock_broker):
     assert received_message == test_data
 
 
+def test_subscribe_multiple_topics(mock_broker):
+    topics = [b"apples", b"pears", b"carrots"]
+
+    pub = get_default_publisher()
+    sub = get_default_subscriber(topics)
+    wait()
+
+    for topic in topics:
+        message = f"hello from {topic.decode()}"
+        pub.send(topic, message)
+        rec_topic, received_message = sub.receive()
+        assert rec_topic == topic
+        assert received_message == message
+
+
 def test_subscriber_without_broker():
     """
     Test the subscriber class directly,


### PR DESCRIPTION
Changed subscribe(topic: bytes) to subscribe(topic: bytes | list[bytes]). 
Added test to test_zmq_wrapper for multiple topics.

Closes #86. 