### PR TITLE
Add option to use strings or bytes to zmq.

### DIFF
--- a/msb/zmq_base/Subscriber.py
+++ b/msb/zmq_base/Subscriber.py
@@ -29,13 +29,18 @@ class Subscriber:
             print(f"failed to bind to zeromq socket: {e}")
             sys.exit(-1)
 
-    def subscribe(self, topic: bytes | list[bytes]):
+    def _subscribe_single_topic(self, topic: bytes | str):
+        if isinstance(topic, str):
+            topic = topic.encode
+        self.socket.setsockopt(zmq.SUBSCRIBE, topic)
+
+    def subscribe(self, topic: bytes | str | list[bytes] | list[str]):
         # Acceps single topic or list of topics
         if isinstance(topic, list):
             for t in topic:
-                self.socket.setsockopt(zmq.SUBSCRIBE, t)
+                self._subscribe_single_topic
         else:
-            self.socket.setsockopt(zmq.SUBSCRIBE, topic)
+            self._subscribe_single_topic
 
     def receive(self) -> tuple[bytes, dict]:
         """

--- a/msb/zmq_base/Subscriber.py
+++ b/msb/zmq_base/Subscriber.py
@@ -31,7 +31,7 @@ class Subscriber:
 
     def _subscribe_single_topic(self, topic: bytes | str):
         if isinstance(topic, str):
-            topic = topic.encode
+            topic = topic.encode()
         self.socket.setsockopt(zmq.SUBSCRIBE, topic)
 
     def subscribe(self, topic: bytes | str | list[bytes] | list[str]):

--- a/test/zmq/test_zmq.py
+++ b/test/zmq/test_zmq.py
@@ -1,0 +1,21 @@
+from msb.zmq_base import get_default_subscriber
+
+
+def test_sub_single_string_topic():
+    get_default_subscriber("test")
+
+
+def test_sub_single_string_bytes():
+    get_default_subscriber(b"test")
+
+
+def test_multiple_strings():
+    get_default_subscriber(["test1", "test2"])
+
+
+def test_multiples_bytes():
+    get_default_subscriber([b"test1", b"test2"])
+
+
+def test_ridiculous_fringe_case():
+    get_default_subscriber([b"test1", "test2"])


### PR DESCRIPTION
Or use a combination of strings and bytes in a list, if you're insane.