### PR TITLE
Imu calibration

### DIFF
--- a/msb/imu/msb_imu.py
+++ b/msb/imu/msb_imu.py
@@ -1,9 +1,11 @@
+import json
+import os
 import signal
 import sys
 
-from msb.imu.icm20948.icm20948 import ICM20948
-from msb.imu.config import IMUConf
 from msb.config import load_config
+from msb.imu.config import IMUConf
+from msb.imu.icm20948.icm20948 import ICM20948
 from msb.zmq_base.Publisher import Publisher, get_default_publisher
 
 
@@ -19,6 +21,16 @@ class IMUService:
         self.publisher = publisher
         self.icm20948 = ICM20948(config)
 
+        conf_dir = os.environ["MSB_CONFIG_DIR"]
+        imu_calibration_subpath = "msb/calibration/imu.json"
+        imu_calibration_file = os.path.join(conf_dir, imu_calibration_subpath)
+        try:
+            with open(imu_calibration_file) as calib_file:
+                calibration = json.load(calib_file)
+        except FileNotFoundError:
+            calibration = {"rot_x_off": 0.0, "rot_y_off": 0.0, "rot_z_off": 0.0}
+        self.calibration = calibration
+
     def run(self):
         with self.icm20948:
             # signal.pause()
@@ -29,6 +41,7 @@ class IMUService:
 
     def process_raw(self, raw) -> dict:
         data = self.align_axes_with_msb_coordinate_system(raw)
+        data = self.apply_calibration(data)
         return data
 
     @staticmethod
@@ -43,6 +56,12 @@ class IMUService:
         data["mag_x"] *= -1
         data["mag_z"] *= -1
 
+        return data
+
+    def apply_calibration(self, data):
+        data["rot_x"] -= self.calibration["rot_x_off"]
+        data["rot_y"] -= self.calibration["rot_y_off"]
+        data["rot_z"] -= self.calibration["rot_z_off"]
         return data
 
 

--- a/scripts/calibrate_imu.py
+++ b/scripts/calibrate_imu.py
@@ -1,0 +1,89 @@
+import json
+import os
+import subprocess
+import sys
+import time
+
+import numpy as np
+from tqdm import tqdm
+
+sys.path.append("..")
+from msb.zmq_base.Subscriber import Subscriber, get_default_subscriber
+
+
+def get_gyro_measurement_data(subscriber: Subscriber, n_meas=100):
+    measurements = np.empty((n_meas, 3))
+    for i in tqdm(range(n_meas)):
+        _, data = subscriber.receive()
+        measurements[i] = [data["rot_x"], data["rot_y"], data["rot_z"]]
+    return measurements
+
+
+def calculate_gyro_offsets(measurements: np.array):
+    means = np.round(measurements.mean(axis=0), decimals=1)
+    return {"x": means[0], "y": means[1], "z": means[2]}
+
+
+def save_calibration(gyro_offsets: dict):
+    conf_dir = os.environ["MSB_CONFIG_DIR"]
+    imu_calibration_subpath = "msb/calibration/imu.json"
+    imu_calibration_file = os.path.join(conf_dir, imu_calibration_subpath)
+    try:
+        with open(imu_calibration_file, "rt") as cal_file:
+            calibration = json.load(cal_file)
+    except FileNotFoundError:
+        calibration = {}
+
+    calibration["rot_x_off"] = gyro_offsets["x"]
+    calibration["rot_y_off"] = gyro_offsets["y"]
+    calibration["rot_z_off"] = gyro_offsets["z"]
+
+    os.makedirs(os.path.dirname(imu_calibration_file), exist_ok=True)
+
+    with open(imu_calibration_file, "wt") as cal_file:
+        json.dump(calibration, cal_file)
+
+    return imu_calibration_file
+
+
+def main(subscriber: Subscriber):
+    print("Welcome to gyroscope calibration.")
+    # imu_topic = input("Enter the imu topic [imu]: ")
+    # imu_topic = imu_topic if imu_topic else "imu"
+    # print(f"imu topic: {imu_topic}")
+    print(
+        "Please place the msb with z axis upwards and do not move it while calibrating."
+    )
+    _ = input("Press Enter to continue.")
+    time.sleep(0.5)
+    print("Measuring...")
+    gyro_measurements = get_gyro_measurement_data(subscriber)
+    print("Calibrating...")
+    gyro_offsets = calculate_gyro_offsets(gyro_measurements)
+    print("The estimated offsets are:")
+    print(
+        f"x={gyro_offsets['x']:.4}, y={gyro_offsets['y']:.4}, z={gyro_offsets['z']:.4}"
+    )
+    yes_no_save = input("Do you want to save estimated offsets? [y/N]: ")
+    save_gyro_offsets = True if yes_no_save.lower() in ["y", "j", "yes"] else False
+    if save_gyro_offsets:
+        calibration_file = save_calibration(gyro_offsets)
+        print(f"Calibration saved to {calibration_file}.")
+    else:
+        print("Calibration not saved.")
+    yes_no_restart = input(
+        "Calibration finished. Do you want to restart the imu service? [y/N]: "
+    )
+    restart_imu_service = True if yes_no_restart.lower() in ["y", "j", "yes"] else False
+    if restart_imu_service:
+        compl_proc = subprocess.run(["sudo", "systemctl", "restart", "msb-imu.service"])
+        if compl_proc.returncode == 0:
+            print("Successfully restarted imu service.")
+        else:
+            print("Could not restart imu service.")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    subscriber = get_default_subscriber("imu")
+    main(subscriber)

--- a/scripts/calibrate_imu.py
+++ b/scripts/calibrate_imu.py
@@ -1,8 +1,11 @@
 import json
 import os
+import pprint
+import signal
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 
 import numpy as np
 from tqdm import tqdm
@@ -11,7 +14,8 @@ sys.path.append("..")
 from msb.zmq_base.Subscriber import Subscriber, get_default_subscriber
 
 
-def get_gyro_measurement_data(subscriber: Subscriber, n_meas=100):
+def get_gyro_measurement_data(subscriber: Subscriber, n_meas=1142):
+    # 8 * 35.7 * 4 =  1142.4 -> approx 4 periods
     measurements = np.empty((n_meas, 3))
     for i in tqdm(range(n_meas)):
         _, data = subscriber.receive()
@@ -21,66 +25,148 @@ def get_gyro_measurement_data(subscriber: Subscriber, n_meas=100):
 
 def calculate_gyro_offsets(measurements: np.array):
     means = np.round(measurements.mean(axis=0), decimals=1)
-    return {"x": means[0], "y": means[1], "z": means[2]}
+    return {"rot_x_off": means[0], "rot_y_off": means[1], "rot_z_off": means[2]}
 
 
-def save_calibration(gyro_offsets: dict):
+def get_default_calibration():
+    return {
+        "rot_x_off": 0.0,
+        "rot_y_off": 0.0,
+        "rot_z_off": 0.0,
+    }
+
+
+###
+# %% Calibration file handling
+###
+
+
+def get_calibration_file_path():
     conf_dir = os.environ["MSB_CONFIG_DIR"]
     imu_calibration_subpath = "msb/calibration/imu.json"
     imu_calibration_file = os.path.join(conf_dir, imu_calibration_subpath)
+    return imu_calibration_file
+
+
+def load_calibration(imu_calibration_file: str):
     try:
         with open(imu_calibration_file, "rt") as cal_file:
             calibration = json.load(cal_file)
     except FileNotFoundError:
         calibration = {}
+    return calibration
 
-    calibration["rot_x_off"] = gyro_offsets["x"]
-    calibration["rot_y_off"] = gyro_offsets["y"]
-    calibration["rot_z_off"] = gyro_offsets["z"]
 
+def dump_calibration(calibration: dict, imu_calibration_file: str):
+    imu_calibration_file = get_calibration_file_path()
     os.makedirs(os.path.dirname(imu_calibration_file), exist_ok=True)
 
     with open(imu_calibration_file, "wt") as cal_file:
         json.dump(calibration, cal_file)
 
-    return imu_calibration_file
+
+def unset_calibration(calibration_file_path):
+    current_calibration = load_calibration(calibration_file_path)
+    print("Current calibration is:")
+    pprint.pp(current_calibration)
+    print("Unsetting calibration.")
+    dump_calibration(get_default_calibration(), calibration_file_path)
+    return current_calibration
+
+
+###
+# %% IMU service controls
+###
+
+
+def control_imu_service(control: str):
+    return subprocess.run(["sudo", "systemctl", control, "msb-imu.service"]).returncode
+
+
+def stop_imu_service():
+    return_code = control_imu_service("stop")
+    if return_code == 0:
+        print("Successfully stopped imu service.")
+    else:
+        print("Could not stop imu service.")
+
+
+def restart_imu_service():
+    return_code = control_imu_service("restart")
+    if return_code == 0:
+        print("Successfully restarted imu service.")
+    else:
+        print("Could not restart imu service.")
+
+
+###
+# %% Run imu (not as a service) for calibration
+###
+@contextmanager
+def imu_with_calibration_settings():
+    # settings taken from https://github.com/wollewald/ICM20948_WE/blob/dfe12a80e48785849aa2b74161ec5d8901cbcfbe/src/ICM20948_WE.cpp#L63
+    imu_parameter = {
+        "acc_filter": "dlpf_5.7",
+        "gyr_filter": "dlpf_5.7",
+        "acc_sensitivity": "2g",
+        "gyr_sensitivity": "250dps",
+        "sample_rate_divisor": 31,
+    }
+    params = [f"{k}={v}" for k, v in imu_parameter.items()]
+    imu_process = subprocess.Popen(
+        ["python", "run/msb_imu.py", "--params", *params],
+        cwd="/home/msb/motion-sensor-box",
+    )
+    time.sleep(2)
+    print("IMU started.")
+    try:
+        yield imu_process
+    finally:
+        imu_process.send_signal(signal.SIGINT)
+        imu_process.wait()
+        print("IMU stopped.")
 
 
 def main(subscriber: Subscriber):
     print("Welcome to gyroscope calibration.")
-    # imu_topic = input("Enter the imu topic [imu]: ")
-    # imu_topic = imu_topic if imu_topic else "imu"
-    # print(f"imu topic: {imu_topic}")
+    print("The imu service will be stopped during calibration.")
     print(
         "Please place the msb with z axis upwards and do not move it while calibrating."
     )
     _ = input("Press Enter to continue.")
-    time.sleep(0.5)
-    print("Measuring...")
-    gyro_measurements = get_gyro_measurement_data(subscriber)
+
+    calibration_file_path = get_calibration_file_path()
+
+    stop_imu_service()
+    old_calibration = unset_calibration(calibration_file_path)
+    time.sleep(1)
+
+    # Measure
+    with imu_with_calibration_settings():
+        print("Measuring...")
+        gyro_measurements = get_gyro_measurement_data(subscriber)
+
+    # Calibrate
     print("Calibrating...")
-    gyro_offsets = calculate_gyro_offsets(gyro_measurements)
+    calibration = calculate_gyro_offsets(gyro_measurements)
     print("The estimated offsets are:")
-    print(
-        f"x={gyro_offsets['x']:.4}, y={gyro_offsets['y']:.4}, z={gyro_offsets['z']:.4}"
-    )
-    yes_no_save = input("Do you want to save estimated offsets? [y/N]: ")
-    save_gyro_offsets = True if yes_no_save.lower() in ["y", "j", "yes"] else False
-    if save_gyro_offsets:
-        calibration_file = save_calibration(gyro_offsets)
-        print(f"Calibration saved to {calibration_file}.")
+    pprint.pp(calibration)
+
+    # Save new calibration values?
+    yes_no_save = input("Do you want to save the newly estimated offsets? [y/N]: ")
+    if yes_no_save.lower() in ["y", "j", "yes"]:
+        dump_calibration(calibration, calibration_file_path)
+        print(f"Calibration saved to {calibration_file_path}.")
     else:
-        print("Calibration not saved.")
+        dump_calibration(old_calibration, calibration_file_path)
+        print("Previous calibration restored.")
+
+    # Restart imu service?
     yes_no_restart = input(
         "Calibration finished. Do you want to restart the imu service? [y/N]: "
     )
-    restart_imu_service = True if yes_no_restart.lower() in ["y", "j", "yes"] else False
-    if restart_imu_service:
-        compl_proc = subprocess.run(["sudo", "systemctl", "restart", "msb-imu.service"])
-        if compl_proc.returncode == 0:
-            print("Successfully restarted imu service.")
-        else:
-            print("Could not restart imu service.")
+    if yes_no_restart.lower() in ["y", "j", "yes"]:
+        restart_imu_service()
     print("Done.")
 
 

--- a/scripts/measure_update_frequency.py
+++ b/scripts/measure_update_frequency.py
@@ -1,0 +1,86 @@
+#!/bin/python3
+
+import argparse
+import sys
+from os import path
+
+import numpy as np
+
+SCRIPT_DIR = path.dirname(path.abspath(__file__))
+sys.path.append(path.dirname(SCRIPT_DIR))
+
+from msb.zmq_base import get_default_subscriber
+
+
+def parse_user_input():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-t",
+        "--topic",
+        type=str,
+        default="",
+        help="topic to subscribe to",
+    )
+
+    parser.add_argument(
+        "-n", "--order", type=int, default=35, help="Order of moving average"
+    )
+
+    return parser.parse_args()
+
+
+class MovingAverageBuffer:
+    def __init__(self, order):
+        self.order = order
+        self.buffer = np.ones(order) * np.nan
+        self.pointer = 0
+
+    def _advance_pointer(self):
+        self.pointer += 1
+        if self.pointer >= self.order:
+            self.pointer = 0
+
+    def append(self, val: float):
+        self.buffer[self.pointer] = val
+        self._advance_pointer()
+
+    def moving_average(self):
+        return np.nanmean(self.buffer)
+
+
+class Frequency:
+    def __init__(self):
+        self.last_timestamp = np.nan
+
+    def update(self, ts):
+        freq = 1 / (ts - self.last_timestamp)
+        self.last_timestamp = ts
+        return freq
+
+
+def main():
+    args = parse_user_input()
+    topic = args.topic
+    order = args.order
+
+    sub = get_default_subscriber(topic)
+
+    buffer = MovingAverageBuffer(order=order)
+    frequency = Frequency()
+
+    try:
+        while True:
+            topic, data = sub.receive()
+            ts = data["epoch"]
+            freq = frequency.update(ts)
+            buffer.append(freq)
+            print(
+                f"topic={topic.decode('utf-8')}, last={freq:.1f} Hz, mov_avg={buffer.moving_average():.2f} Hz"
+            )
+    except KeyboardInterrupt:
+        print("measure_update_frequency.py exit")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements a simple calibration script.
Requires to install python3-tqdm.
Will create a `calibration` folder under the config dir. 
Will create an `imu.json` file in that dir.
Calibration offsets for the gyroscope are stored in that file and will be used by the msb_imu.service once restarted.
Calibration offsets are rounded to 1 decimal place as they are not stable for more places, i.e. following measurements agree to only one decimal place.