### PR TITLE
changed msb-status topic from 'status' to 'sta'

### DIFF
--- a/config/msb/conf.d/status.yaml
+++ b/config/msb/conf.d/status.yaml
@@ -1,4 +1,4 @@
-topic: "status"
+topic: "sta"
 seconds_between_updates: 10.0
 get_uptime: True
 get_disk_usage: True

--- a/msb/status/config.py
+++ b/msb/status/config.py
@@ -2,7 +2,7 @@ from msb.config import MSBConf
 
 
 class StatusConf(MSBConf):
-    topic: bytes = b"status"
+    topic: bytes = b"sta"
     seconds_between_updates: float = 10.0
 
     get_uptime: bool = True


### PR DESCRIPTION
changed default topic for status service from `status` to `sta` to be in line with all other topics (3 letters)