### PR TITLE
supply n_cores instead of current load in system_load

### DIFF
--- a/msb/status/status.py
+++ b/msb/status/status.py
@@ -36,10 +36,10 @@ def network_status() -> dict:
 
 
 def system_load() -> dict:
-    current = psutil.cpu_percent()
+    n_cores = psutil.cpu_count(logical=True)
     averages = psutil.getloadavg()
     return {
-        "current": current,
+        "n_cores": n_cores,
         "average_1min": averages[0],
         "average_5min": averages[1],
         "average_15min": averages[2],

--- a/msb/status/status.py
+++ b/msb/status/status.py
@@ -39,7 +39,7 @@ def system_load() -> dict:
     n_cores = psutil.cpu_count(logical=True)
     averages = psutil.getloadavg()
     return {
-        "n_cores": n_cores,
+        "max": float(n_cores),
         "average_1min": averages[0],
         "average_5min": averages[1],
         "average_15min": averages[2],


### PR DESCRIPTION
Update system_load status to contain the number of cpu cores instead of the current load.
It is not reasonable to consider the current load in a status message that is send e.g. every 10 seconds. The average loads provide a better insight. 
The number of cores is needed to interpret the average loads. (maximum load  = number of cores)