### PR TITLE
Refactor mqtt forwarder

### DIFF
--- a/msb/network/mqtt/forwarder.py
+++ b/msb/network/mqtt/forwarder.py
@@ -8,7 +8,7 @@ def map_topic(zmq_topic, mapping):
 
 
 def main():
-    config: MQTTConf = load_config("mqtt")
+    config: MQTTConf = load_config(MQTTConf(), "mqtt")
     sub = get_subscriber("zmq", config.topics)
     pub = get_publisher("mqtt")
 

--- a/msb/network/mqtt/subscriber.py
+++ b/msb/network/mqtt/subscriber.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from queue import SimpleQueue
+from collections.abc import Sequence
 
 from msb.config import load_config
 from msb.network.packer import get_unpacker
@@ -46,7 +47,7 @@ class MQTT_Subscriber(MQTT_Base, Subscriber):
         Subscribe to one or multiple topics
         """
         # if subscribing to multiple topics, use a list of tuples
-        if isinstance(topics, list):
+        if isinstance(topics, Sequence):
             self._subscribe_multiple_topics(topics)
         else:
             self.client.subscribe(topics, self.config.qos)

--- a/msb/network/zmq/subscriber.py
+++ b/msb/network/zmq/subscriber.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import zmq
 import json
 import sys
+from collections.abc import Sequence
 
 from .config import ZMQConf
 from msb.config import load_config
@@ -36,7 +37,7 @@ class ZMQ_Subscriber(Subscriber):
 
     def subscribe(self, topic: bytes | str | list[bytes] | list[str]):
         # Accepts single topic or list of topics
-        if isinstance(topic, list):
+        if isinstance(topic, Sequence):
             for t in topic:
                 self._subscribe_single_topic(t)
         else:

--- a/run/msb_mqtt.py
+++ b/run/msb_mqtt.py
@@ -4,7 +4,7 @@ import sys
 SCRIPT_DIR = path.dirname(path.abspath(__file__))
 sys.path.append(path.dirname(SCRIPT_DIR))
 
-import msb.mqtt.msb_mqtt as mqtt
 
 if __name__ == "__main__":
-    mqtt.main()
+    import msb.network.mqtt.forwarder as mqtt_forwarder
+    mqtt_forwarder.main()


### PR DESCRIPTION
Reimplemented the **ZMQ to MQTT** forwarder running as msb_mqtt.py to use the refactored networking classes.

This takes advantage of the recently implemented thread checking. 

Further changes in this PR:
* When subscribing to multiple topics, mqtt and zmq subscriber now allow tuples as well as lists by checking against `collections.abc.Sequence`